### PR TITLE
fix: correct mismatched closing tag in ProjectLayout.astro

### DIFF
--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -55,7 +55,7 @@ const backLink = type === 'contribution' ? '/#contributions' : '/#creations';
         <ul class="tags">
           {tags.map((tag) => (
             <li>
-              <a class="tag" href={`/tags/${tag.toLowerCase().replace(/\s+/g, '-')}`}>{tag}</span></a>
+              <a class="tag" href={`/tags/${tag.toLowerCase().replace(/\s+/g, '-')}`}>{tag}</a>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
The tag link in the tags list was using `</span>` to close an `<a>` element, causing a compiler error. Changed to use the correct `</a>` closing tag.

Fixes build failure: "Closing tag '</span>' has no matching opening tag"